### PR TITLE
Add blur placeholders for images

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import NextImage from 'next/image'
 import { Container, Image, Text, Title, Divider, Flex, List, ListItem } from '@mantine/core'
-import { googleStorageImagesFolder } from '../constants'
 import styles from './styles.module.scss'
 import { ShowMore } from '../components/showmore'
+import leo from '@/public/images/leo-shirokov.png'
+import aboutCircle from '@/public/images/about-circle.png'
 
 export const dynamic = 'force-static'
 
@@ -22,9 +23,10 @@ export default function About() {
           width={79}
           height={125}
           sizes="(max-width: 768px) 100vw, 50vw"
-          src={`${googleStorageImagesFolder}a98daba6-1f4e-4614-aecd-ab5cb189fcaf.png`}
+          src={leo}
           className={styles.leoImage}
           component={NextImage}
+          placeholder="blur"
         />
         I am a collector and restorer of antique barometers, a member of the Society for the History
         of Technology (SHOT), European Society for Environmental History (ESEH) and the
@@ -84,8 +86,9 @@ export default function About() {
           width={160}
           height={160}
           sizes="(max-width: 576px) 70vw, 160px"
-          src="/images/about-circle.png"
+          src={aboutCircle}
           component={NextImage}
+          placeholder="blur"
         />
       </Flex>
       <Divider mx="xl" />

--- a/app/api/v2/barometers/[slug]/getters.ts
+++ b/app/api/v2/barometers/[slug]/getters.ts
@@ -36,11 +36,7 @@ export const getBarometer = withPrisma(async (prisma, slug: string) => {
     },
   })
   if (barometer === null) throw new NotFoundError()
-  return {
-    ...barometer,
-    // temporarily
-    images: barometer.images.map(img => img.url),
-  }
+  return barometer
 })
 
 export type BarometerDTO = Awaited<ReturnType<typeof getBarometer>>

--- a/app/api/v2/barometers/[slug]/route.ts
+++ b/app/api/v2/barometers/[slug]/route.ts
@@ -4,7 +4,7 @@ import { getBarometer } from './getters'
 import { withPrisma } from '@/prisma/prismaClient'
 import { NotFoundError } from '@/app/errors'
 import { revalidateCategory } from '../revalidate'
-import { barometerRoute } from '@/app/constants'
+import { barometerRoute, newArrivals } from '@/app/constants'
 
 interface Params {
   params: {
@@ -60,7 +60,10 @@ export const DELETE = withPrisma(
       })
 
       revalidatePath(barometerRoute + barometer.slug)
+      revalidatePath(newArrivals)
       await revalidateCategory(prisma, barometer.categoryId)
+
+      // TODO: Delete image from google storage
 
       return NextResponse.json({ message: 'Barometer deleted successfully' }, { status: 200 })
     } catch (error) {

--- a/app/api/v2/barometers/getters.ts
+++ b/app/api/v2/barometers/getters.ts
@@ -67,6 +67,7 @@ export const getBarometersByParams = withPrisma(
             select: {
               url: true,
               order: true,
+              blurData: true,
             },
             orderBy: {
               order: 'asc',

--- a/app/api/v2/barometers/imageBlur.ts
+++ b/app/api/v2/barometers/imageBlur.ts
@@ -1,0 +1,37 @@
+import sharp from 'sharp'
+import { googleStorageImagesFolder } from '@/app/constants'
+
+async function getGoogleStorageImage(imgUrl: string) {
+  const url = googleStorageImagesFolder + imgUrl
+  const res = await fetch(url)
+  return res.arrayBuffer()
+}
+
+async function getBlurDateBase64(imgUrl: string) {
+  const imgContent = await getGoogleStorageImage(imgUrl)
+  return sharp(imgContent)
+    .resize(32, 32, { fit: 'inside' })
+    .flatten({ background: { r: 239, g: 239, b: 239 } })
+    .avif()
+    .blur(1)
+    .toBuffer()
+    .then(buffer => `data:image/avif;base64,${buffer.toString('base64')}`)
+}
+
+export async function getImagesMeta(
+  images: {
+    url: string
+    order: number
+    name: string
+  }[],
+) {
+  return Promise.all(
+    images.map(async image => {
+      const blurData = await getBlurDateBase64(image.url)
+      return {
+        ...image,
+        blurData,
+      }
+    }),
+  )
+}

--- a/app/api/v2/barometers/route.ts
+++ b/app/api/v2/barometers/route.ts
@@ -8,6 +8,7 @@ import { DEFAULT_PAGE_SIZE } from '../parameters'
 import { getBarometersByParams } from './getters'
 import { barometerRoute, newArrivals } from '@/app/constants'
 import { revalidateCategory } from './revalidate'
+import { getImagesMeta } from './imageBlur'
 
 /**
  * Get barometer list
@@ -45,7 +46,7 @@ export const POST = withPrisma(async (prisma, req: NextRequest) => {
       data: {
         ...barometer,
         images: {
-          create: images,
+          create: await getImagesMeta(images),
         },
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -89,7 +90,7 @@ export const PUT = withPrisma(async (prisma, req: NextRequest) => {
             ...newData,
             // attach new images
             images: {
-              create: images,
+              create: await getImagesMeta(images),
             },
             updatedAt: new Date(),
           },

--- a/app/api/v2/categories/[name]/getters.ts
+++ b/app/api/v2/categories/[name]/getters.ts
@@ -17,6 +17,7 @@ export const getCategory = withPrisma((prisma, name: string) =>
       image: {
         select: {
           url: true,
+          blurData: true,
         },
       },
     },

--- a/app/api/v2/categories/getters.ts
+++ b/app/api/v2/categories/getters.ts
@@ -13,6 +13,7 @@ export const getCategories = withPrisma(prisma =>
       image: {
         select: {
           url: true,
+          blurData: true,
         },
       },
     },

--- a/app/api/v2/search/search.ts
+++ b/app/api/v2/search/search.ts
@@ -41,6 +41,7 @@ export const searchBarometers = withPrisma(
             take: 1,
             select: {
               url: true,
+              blurData: true,
             },
           },
         },

--- a/app/collection/categories/[...category]/page.tsx
+++ b/app/collection/categories/[...category]/page.tsx
@@ -79,7 +79,7 @@ export default async function Collection({ params: { category } }: CollectionPro
             <GridCol span={{ base: 6, xs: 3, lg: 3 }} key={id}>
               <BarometerCard
                 priority={i < 8}
-                image={googleStorageImagesFolder + images[0].url}
+                image={images[0]}
                 name={name}
                 link={barometerRoute + slug}
                 manufacturer={manufacturer?.name}

--- a/app/collection/items/[slug]/components/carousel.tsx
+++ b/app/collection/items/[slug]/components/carousel.tsx
@@ -13,13 +13,13 @@ import 'swiper/css/zoom'
 import 'swiper/css/navigation'
 import 'swiper/css/pagination'
 import './styles.css'
+import { googleStorageImagesFolder } from '@/app/constants'
 
 interface ImageCarouselProps {
-  images: string[]
   barometer: BarometerDTO
 }
 
-export function ImageCarousel({ images, barometer }: ImageCarouselProps) {
+export function ImageCarousel({ barometer }: ImageCarouselProps) {
   return (
     <Box style={{ overflow: 'hidden', position: 'relative' }}>
       <IsAdmin>
@@ -27,7 +27,7 @@ export function ImageCarousel({ images, barometer }: ImageCarouselProps) {
       </IsAdmin>
       <Swiper
         zoom
-        loop={images.length > 1}
+        loop={barometer.images.length > 1}
         navigation
         modules={[Zoom, Navigation, Pagination]}
         pagination={{
@@ -37,8 +37,8 @@ export function ImageCarousel({ images, barometer }: ImageCarouselProps) {
           },
         }}
       >
-        {images.map((image, i) => (
-          <SwiperSlide key={image}>
+        {barometer.images.map((image, i) => (
+          <SwiperSlide key={image.id}>
             <Box className="swiper-zoom-container">
               <Image
                 priority={i === 0}
@@ -46,10 +46,12 @@ export function ImageCarousel({ images, barometer }: ImageCarouselProps) {
                 quality={60}
                 width={200}
                 height={200}
-                src={image}
+                src={googleStorageImagesFolder + image.url}
                 alt={barometer.name}
                 component={NextImage}
                 sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                placeholder="blur"
+                blurDataURL={image.blurData}
               />
             </Box>
           </SwiperSlide>

--- a/app/collection/items/[slug]/components/edit-fields/images-edit.tsx
+++ b/app/collection/items/[slug]/components/edit-fields/images-edit.tsx
@@ -23,7 +23,7 @@ import {
   arrayMove,
   horizontalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useDisclosure } from '@mantine/hooks'
 import { BarometerDTO } from '@/app/types'
 import sx from './styles.module.scss'
@@ -87,6 +87,7 @@ function SortableImage({
   )
 }
 export function ImagesEdit({ barometer, size, ...props }: ImagesEditProps) {
+  const barometerImages = useMemo(() => barometer.images.map(img => img.url), [barometer])
   const [isUploading, setIsUploading] = useState(false)
   const [opened, { open, close }] = useDisclosure()
   const form = useForm<FormProps>({
@@ -95,10 +96,10 @@ export function ImagesEdit({ barometer, size, ...props }: ImagesEditProps) {
     },
   })
   useEffect(() => {
-    if (!barometer.images || !opened) return
-    form.setFieldValue('images', barometer.images)
+    if (!barometerImages || !opened) return
+    form.setFieldValue('images', barometerImages)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [barometer.images, opened])
+  }, [barometerImages, opened])
 
   const handleDragEnd = (event: any) => {
     const { active, over } = event
@@ -119,7 +120,7 @@ export function ImagesEdit({ barometer, size, ...props }: ImagesEditProps) {
     setIsUploading(true)
     try {
       // erase deleted images
-      const extraFiles = barometer.images?.filter(img => !form.values.images.includes(img))
+      const extraFiles = barometerImages?.filter(img => !form.values.images.includes(img))
       if (extraFiles) await Promise.all(extraFiles?.map(deleteImage))
       const updatedBarometer = {
         id: barometer.id,
@@ -178,7 +179,7 @@ export function ImagesEdit({ barometer, size, ...props }: ImagesEditProps) {
     setIsUploading(true)
     try {
       // if the image file was uploaded but not yet added to the barometer
-      if (!barometer.images?.includes(img)) await deleteImage(img)
+      if (!barometerImages?.includes(img)) await deleteImage(img)
       form.setFieldValue('images', old => old.filter(file => !file.includes(img)))
     } catch (error) {
       showError(error instanceof Error ? error.message : 'Error deleting file')
@@ -191,7 +192,7 @@ export function ImagesEdit({ barometer, size, ...props }: ImagesEditProps) {
     // delete unused files from storage
     try {
       setIsUploading(true)
-      const extraImages = form.values.images.filter(img => !barometer.images?.includes(img))
+      const extraImages = form.values.images.filter(img => !barometerImages?.includes(img))
       await Promise.all(extraImages.map(deleteImage))
     } catch (error) {
       // do nothing

--- a/app/collection/items/[slug]/page.tsx
+++ b/app/collection/items/[slug]/page.tsx
@@ -80,10 +80,7 @@ export default async function BarometerItem({ params: { slug } }: BarometerItemP
     <Container size="xl">
       <Box px={{ base: 'none', sm: 'xl' }} pb={{ base: 'xl', sm: '5rem' }}>
         <BreadcrumbsComponent catId={barometer.collectionId} type={barometer.category.name} />
-        <ImageCarousel
-          barometer={barometer}
-          images={barometer.images.map(image => googleStorageImagesFolder + image)}
-        />
+        <ImageCarousel barometer={barometer} />
         <Box mb="md">
           <Title
             className={sx.title}

--- a/app/collection/new-arrivals/page.tsx
+++ b/app/collection/new-arrivals/page.tsx
@@ -3,7 +3,7 @@ import { Container, Grid, GridCol, Stack, Title } from '@mantine/core'
 import { fetchBarometerList } from '@/utils/fetch'
 import { BarometerCard } from '@/app/components/barometer-card'
 import { Pagination } from '@/app/components/pagination'
-import { googleStorageImagesFolder, barometerRoute } from '@/app/constants'
+import { barometerRoute } from '@/app/constants'
 
 const itemsOnPage = 12
 
@@ -30,7 +30,7 @@ export default async function NewArrivals({ searchParams }: newArrivalsProps) {
             <GridCol span={{ base: 6, xs: 3, lg: 3 }} key={id}>
               <BarometerCard
                 priority={i < 8}
-                image={googleStorageImagesFolder + images[0].url}
+                image={images[0]}
                 name={name}
                 link={barometerRoute + slug}
                 manufacturer={manufacturer?.name}

--- a/app/components/barometer-card/barometer-card.tsx
+++ b/app/components/barometer-card/barometer-card.tsx
@@ -2,9 +2,11 @@ import { Box, Text, Anchor } from '@mantine/core'
 import Link from 'next/link'
 import NextImage from 'next/image'
 import styles from './styles.module.scss'
+import { BarometerListDTO } from '@/app/types'
+import { googleStorageImagesFolder } from '@/app/constants'
 
 interface BarometerCardProps {
-  image: string
+  image: BarometerListDTO['barometers'][number]['images'][number]
   name: string
   link: string
   manufacturer?: string
@@ -26,11 +28,13 @@ export async function BarometerCard({
             priority={priority}
             loading={priority ? 'eager' : 'lazy'}
             quality={50}
-            src={image}
+            src={googleStorageImagesFolder + image.url}
             alt={name}
             fill
             sizes="(max-width: 575px) 50vw, (max-width: 1350px) 25vw, 20vw"
             style={{ objectFit: 'contain' }}
+            placeholder="blur"
+            blurDataURL={image.blurData ?? undefined}
           />
         </Box>
         <Text mb="0.2rem" size="xs" fw={500} lts={1} tt="uppercase" ta="center">

--- a/app/components/category-card/category-card.tsx
+++ b/app/components/category-card/category-card.tsx
@@ -3,11 +3,12 @@ import NextLink from 'next/link'
 import NextImage from 'next/image'
 import { FC } from 'react'
 import styles from './category-card.module.scss'
+import { CategoryDTO } from '@/app/types'
 
 interface CategoryCardProps {
   name: string
   link: string
-  image?: string
+  image?: CategoryDTO['image']
   priority: boolean
 }
 
@@ -23,12 +24,14 @@ export const CategoryCard: FC<CategoryCardProps> = ({ name, link, image, priorit
               loading={priority ? 'eager' : 'lazy'}
               quality={50}
               sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-              src={image}
+              src={image.url}
               alt={name}
               className={styles.bg_image}
               style={{
                 objectFit: name === 'Recorders' ? 'cover' : 'contain',
               }}
+              placeholder="blur"
+              blurDataURL={image.blurData}
             />
           )}
           <Title component="h3" className={styles.title}>

--- a/app/components/heading-image/heading-image.tsx
+++ b/app/components/heading-image/heading-image.tsx
@@ -2,6 +2,7 @@ import { Box, Title, Container } from '@mantine/core'
 import NextImage from 'next/image'
 import { FC } from 'react'
 import styles from './heading-image.module.scss'
+import headingImage from '@/public/images/landing-header.png'
 
 export const HeadingImage: FC = () => {
   return (
@@ -11,9 +12,10 @@ export const HeadingImage: FC = () => {
         quality={50}
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
         alt="Barograph"
-        src="/images/landing-header.png"
+        src={headingImage}
         fill
         className={styles.image}
+        placeholder="blur"
       />
       <Box className={styles.textContainer}>
         <Box>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ export default async function HomePage() {
             <GridCol key={id} span={{ base: 12, xs: 6, lg: 4 }}>
               <CategoryCard
                 priority={i < 3}
-                image={image.url}
+                image={image}
                 name={label}
                 link={categoriesRoute + name.toLowerCase()}
               />

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,5 +1,5 @@
 import { Box, Container, Stack, Title } from '@mantine/core'
-import { googleStorageImagesFolder, barometerRoute } from '../constants'
+import { barometerRoute } from '../constants'
 import { SearchItem } from './search-item'
 import { searchBarometers } from '@/utils/fetch'
 import { SearchInfo } from './search-info'
@@ -23,7 +23,7 @@ export default async function Search({ searchParams }: SearchProps) {
           <Stack gap="md" p={0}>
             {barometers.map(({ id, name, manufacturer, image, slug, dateDescription }) => (
               <SearchItem
-                image={image ? googleStorageImagesFolder + image.url : undefined}
+                image={image}
                 name={name}
                 manufacturer={manufacturer?.name}
                 link={barometerRoute + slug}

--- a/app/search/search-item.tsx
+++ b/app/search/search-item.tsx
@@ -2,9 +2,11 @@ import { Text, Group, Image, Anchor, Box, Stack, Paper } from '@mantine/core'
 import NextImage from 'next/image'
 import Link from 'next/link'
 import styles from './style.module.css'
+import { SearchResultsDTO } from '../types'
+import { googleStorageImagesFolder } from '../constants'
 
 interface ItemProps {
-  image?: string
+  image: SearchResultsDTO['barometers'][number]['image']
   name: string
   link: string
   manufacturer?: string
@@ -22,9 +24,11 @@ export function SearchItem({ image, link, name, manufacturer, dating }: ItemProp
               component={NextImage}
               fill
               alt={name}
-              src={image}
+              src={image?.url && googleStorageImagesFolder + image.url}
               style={{ objectFit: 'contain' }}
               sizes="100px"
+              placeholder="blur"
+              blurDataURL={image?.blurData}
             />
           </Box>
           <Stack gap="xs" justify="center" mih="70px">

--- a/prisma/migrations/20241229231013_add_blur_data_to_image/migration.sql
+++ b/prisma/migrations/20241229231013_add_blur_data_to_image/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Image" ADD COLUMN     "blurData" TEXT;

--- a/prisma/migrations/20241230062723_require_blur_data/migration.sql
+++ b/prisma/migrations/20241230062723_require_blur_data/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `blurData` on table `Image` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Image" ALTER COLUMN "blurData" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,13 +12,14 @@ datasource db {
 model Image {
   id          String      @id @default(uuid())
   url         String
+  blurData    String
   description String?
   name        String?
   createdAt   DateTime    @default(now())
   updatedAt   DateTime    @updatedAt
   categories  Category?   @relation("CategoryImage")
   barometers  Barometer[] @relation("BarometerImages")
-  order       Int?        
+  order       Int?
 }
 
 model Category {

--- a/utils/addBlurDataToImages.ts
+++ b/utils/addBlurDataToImages.ts
@@ -1,0 +1,66 @@
+import { Storage } from '@google-cloud/storage'
+import sharp from 'sharp'
+import { withPrisma } from '../prisma/prismaClient'
+
+const decodedPrivateKey = Buffer.from(process.env.GCP_PRIVATE_KEY!, 'base64').toString('utf-8')
+const storage = new Storage({
+  projectId: process.env.GCP_PROJECT_ID,
+  credentials: {
+    client_email: process.env.GCP_CLIENT_EMAIL,
+    private_key: decodedPrivateKey,
+  },
+})
+const bucket = storage.bucket(process.env.GCP_BUCKET_NAME!)
+
+/**
+ * This function processes images stored either locally or in Google Cloud Storage,
+ * generates a small blurred placeholder for each image in AVIF format, and updates
+ * the database with the generated placeholder. The process is performed in batches
+ * to optimize resource usage.
+ */
+const main = withPrisma(async prisma => {
+  const images = await prisma.image.findMany()
+
+  const batchSize = 10
+  for (let i = 0; i < images.length; i += batchSize) {
+    const batch = images.slice(i, i + batchSize)
+    await Promise.all(
+      batch.map(async image => {
+        try {
+          let imgContent: Buffer | ArrayBuffer
+          if (image.url.startsWith('/images')) {
+            const res = await fetch(`https://www.barometers.info${image.url}`)
+            imgContent = await res.arrayBuffer()
+          } else {
+            const file = bucket.file(image.url)
+            ;[imgContent] = await file.download()
+          }
+
+          const blurDataURL = await sharp(imgContent)
+            .resize(32, 32, { fit: 'inside' })
+            .flatten({ background: { r: 239, g: 239, b: 239 } })
+            .avif()
+            .blur(1)
+            .toBuffer()
+            .then(buffer => `data:image/avif;base64,${buffer.toString('base64')}`)
+
+          // update DB record
+          await prisma.image.update({
+            where: { id: image.id },
+            data: { blurData: blurDataURL },
+          })
+
+          // eslint-disable-next-line no-console
+          console.log(`Обработано изображение: ${image.url}`)
+        } catch (error) {
+          console.error(
+            `Ошибка при обработке ${image.url}:`,
+            error instanceof Error ? error.message : 'Unable to process image',
+          )
+        }
+      }),
+    )
+  }
+})
+
+main()

--- a/utils/fetch.ts
+++ b/utils/fetch.ts
@@ -32,7 +32,7 @@ export async function fetchBarometerList(
 ): Promise<BarometerListDTO> {
   const url = baseUrl + barometersApiRoute
   const res = await fetch(`${url}?${new URLSearchParams(searchParams)}`, {
-    next: { revalidate: 600 },
+    cache: 'no-cache',
   })
   return res.json()
 }


### PR DESCRIPTION
Generate blur placeholders for images during barometer creation and updates, enhancing image loading performance and user experience. Additionally, update the database schema to include a new column for storing blur data.