### PR TITLE
Show close button in modal after image loading

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -52,7 +52,7 @@ export default function About() {
           <span className={styles.bookTitle}>Barometer Odyssey*</span>, a book that explores the
           evolution of barometers over time.
         </Text>
-        <div className="xs:justify-start mb-3 flex justify-center gap-2 py-3">
+        <div className="mb-3 flex justify-center gap-2 py-3 xs:justify-start">
           <Anchor
             href="https://www.ozon.ru/product/barometr-odisseya-1918748239/?at=mqtkyRVAEhMBgPkoc8x4EGrHK39QKWiopqMgXhv53xWD&keywords=%D0%B1%D0%B0%D1%80%D0%BE%D0%BC%D0%B5%D1%82%D1%80+%D0%BE%D0%B4%D0%B8%D1%81%D1%81%D0%B5%D1%8F"
             target="_blank"

--- a/app/collection/items/[slug]/page.tsx
+++ b/app/collection/items/[slug]/page.tsx
@@ -187,7 +187,7 @@ export default async function Page({ params: { slug } }: Props) {
           </Grid>
           <Group align="center" gap="sm">
             <Title fw={600} order={2} tt="capitalize">
-              Description
+              Object Overview
             </Title>
             <IsAdmin>
               <TextAreaEdit barometer={barometer} property="description" />

--- a/app/components/modal/image-lightbox.tsx
+++ b/app/components/modal/image-lightbox.tsx
@@ -26,15 +26,18 @@ export function ImageLightbox({ src, name }: ImageLightboxProps) {
       />
 
       <ZoomModal isOpened={opened} close={close}>
-        <NextImage
-          className="h-auto max-h-screen w-auto"
-          width={1000}
-          height={1000}
-          quality={100}
-          src={src}
-          alt={name}
-          loading="lazy"
-        />
+        {({ onLoad }) => (
+          <NextImage
+            className="h-auto max-h-screen w-auto"
+            width={1000}
+            height={1000}
+            quality={100}
+            src={src}
+            alt={name}
+            loading="lazy"
+            onLoad={onLoad}
+          />
+        )}
       </ZoomModal>
     </>
   )

--- a/app/components/modal/zoom-modal.tsx
+++ b/app/components/modal/zoom-modal.tsx
@@ -1,19 +1,21 @@
 'use client'
 
 import { CloseButton } from '@mantine/core'
-import { PropsWithChildren, useEffect, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'motion/react'
 import { useClickOutside } from '@mantine/hooks'
 
-interface ZoomModalProps extends PropsWithChildren {
+interface ZoomModalProps {
   isOpened: boolean
   close: () => void
+  children: ReactNode | ((props: { onLoad: () => void }) => ReactNode)
 }
 
 export function ZoomModal({ children, close, isOpened }: ZoomModalProps) {
   const [mounted, setMounted] = useState(false)
   const childrenContainer = useClickOutside(close)
+  const [imageLoaded, setImageLoaded] = useState(false)
 
   // the component is rendered on the client
   useEffect(() => {
@@ -52,11 +54,16 @@ export function ZoomModal({ children, close, isOpened }: ZoomModalProps) {
               exit={{ scale: 0.8, opacity: 0 }}
               className="relative"
             >
-              <CloseButton
-                onClick={close}
-                className="!absolute right-2 top-2 !bg-neutral-100 hover:!bg-neutral-200"
-              />
-              {children}
+              {imageLoaded && (
+                <CloseButton
+                  onClick={close}
+                  className="!absolute right-2 top-2 !bg-neutral-100 hover:!bg-neutral-200"
+                />
+              )}
+
+              {children && typeof children === 'function'
+                ? children({ onLoad: () => setImageLoaded(true) })
+                : children}
             </motion.div>
           </div>
         </>

--- a/app/components/modal/zoom-modal.tsx
+++ b/app/components/modal/zoom-modal.tsx
@@ -9,7 +9,7 @@ import { useClickOutside } from '@mantine/hooks'
 interface ZoomModalProps {
   isOpened: boolean
   close: () => void
-  children: ReactNode | ((props: { onLoad: () => void }) => ReactNode)
+  children: (props: { onLoad: () => void }) => ReactNode
 }
 
 export function ZoomModal({ children, close, isOpened }: ZoomModalProps) {
@@ -61,9 +61,7 @@ export function ZoomModal({ children, close, isOpened }: ZoomModalProps) {
                 />
               )}
 
-              {children && typeof children === 'function'
-                ? children({ onLoad: () => setImageLoaded(true) })
-                : children}
+              {children({ onLoad: () => setImageLoaded(true) })}
             </motion.div>
           </div>
         </>


### PR DESCRIPTION
Ensure the close button in the modal only appears after the image has fully loaded, improving user experience.